### PR TITLE
Remove MvvmCross NuGet package 

### DIFF
--- a/src/2Day.App.Shared/2Day.App.Shared.csproj
+++ b/src/2Day.App.Shared/2Day.App.Shared.csproj
@@ -116,16 +116,6 @@
       <Name>2Day.Vercors.Shared</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Reference Include="MvvmCross.Core, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvvmCross.Core.4.4.0\lib\portable-net45+win+wpa81+wp80\MvvmCross.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="MvvmCross.Platform, Version=4.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MvvmCross.Platform.4.4.0\lib\portable-net45+win+wpa81+wp80\MvvmCross.Platform.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-  </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/2Day.App.Shared/packages.config
+++ b/src/2Day.App.Shared/packages.config
@@ -1,6 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="portable46-net451+win81" />
-  <package id="MvvmCross.Core" version="4.4.0" targetFramework="portable45-net45+win8+wpa81" />
-  <package id="MvvmCross.Platform" version="4.4.0" targetFramework="portable45-net45+win8+wpa81" />
 </packages>


### PR DESCRIPTION
fixes #3 

The MVVMCross NuGet package is referenced but it's never used.